### PR TITLE
Add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Platform.sh Config Reader (Python)
 
+[![CircleCI Status](https://circleci.com/gh/platformsh/config-reader-python.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/platformsh/config-reader-python)
+
 This library provides a streamlined and easy to use way to interact with a Platform.sh environment. It offers utility methods to access routes and relationships more cleanly than reading the raw environment variables yourself.
 
 This library requires Python 3.5 or later.


### PR DESCRIPTION
Before using a library, I like being able to verify that the build is passing. Therefore, it's practical to have it in the README so that one doesn't have to look it up manually.