### PR TITLE
Fix property description

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,6 @@ config.route("main")
 
 The `route()` method takes a single string for the route ID ("main" in this case) and returns the corresponding route array.  If the route is not found it will throw an exception.
 
-To access all routes, or to search for a route that has no ID, the `routes()` method returns an dictionary of routes keyed by their URL.  That mirrors the structure of the `PLATFORM_ROUTES` environment variable.
+To access all routes, or to search for a route that has no ID, the `routes` property returns a dictionary of routes keyed by their URL.  That mirrors the structure of the `PLATFORM_ROUTES` environment variable.
 
 If called in the build phase an exception is thrown.


### PR DESCRIPTION
`routes()` does not work, but `routes` does:

```
./manage.py shell
Python 3.7.0 (default, Aug 20 2018, 13:43:00) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from platformshconfig import Config
>>> config = Config()
>>> config.routes()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
TypeError: 'dict' object is not callable
>>> config.routes
{'https://www…
```