### PR TITLE
include the CHANGELOG.md file in the python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 # Include the license file
 include LICENSE
+# Include the changelog file
+include CHANGELOG.md
 # Include test data
 include tests/valid/*


### PR DESCRIPTION
It's being used by `setup.py`, and if it's absent it fails to build like so:

```text
        Collecting platformshconfig (from -r requirements.pinned.txt (line 17))
          Downloading https://files.pythonhosted.org/packages/b1/a2/92d625da9b0a4c29bc096c0ebe3fd0db53cb2ef9f5e4d299329810824d4f/platformshconfig-2.3.1.tar.gz
            Complete output from command python setup.py egg_info:
            Traceback (most recent call last):
              File "<string>", line 1, in <module>
              File "/tmp/pip-build-_tVzDp/platformshconfig/setup.py", line 20, in <module>
                with open('CHANGELOG.md', 'r', encoding='utf-8') as f:
              File "/opt/python/2.7/lib/python2.7/codecs.py", line 898, in open
                file = __builtin__.open(filename, mode, buffering)
            IOError: [Errno 2] No such file or directory: 'CHANGELOG.md'

            ----------------------------------------
        W: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-_tVzDp/platformshconfig/
```