### PR TITLE
Update Python testing versions

### DIFF
--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python: [ '3.5', '3.6', '3.7', '3.8' ]
+                python: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-python@v1

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -17,5 +17,6 @@ jobs:
               with:
                   python-version: ${{ matrix.python }}
             - run: python -m pip install --upgrade pipenv wheel
+            - run: pipenv --python ${{ matrix.python }}
             - run: pipenv install
             - run: pipenv run "pytest"


### PR DESCRIPTION
3.6 no longer a valid version https://github.com/platformsh/config-reader-python/actions/runs/6930169258/job/18849325006?pr=40

Closes https://github.com/platformsh/config-reader-python/pull/38